### PR TITLE
Implement IP address change detection mechanism

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{worker::{CyborgClient, WorkerData}, error::Result};
+use crate::{error::Result, worker::{CyborgClient, IpResponse, WorkerData}};
 use std::path::PathBuf;
 use subxt::utils::AccountId32;
 use subxt::{OnlineClient, PolkadotConfig};
@@ -186,6 +186,12 @@ impl CyborgClientBuilder<AccountKeypair> {
                 // Create an online client that connects to the specified Substrate node URL.
                 let client = OnlineClient::<PolkadotConfig>::from_url(url).await?;
 
+                let current_ip = reqwest::get("https://api.ipify.org?format=json")
+                .await?
+                .json::<IpResponse>()
+                .await?
+                .ip;
+
                 Ok(CyborgClient {
                     client,
                     keypair: self.keypair.0,
@@ -198,6 +204,7 @@ impl CyborgClientBuilder<AccountKeypair> {
                     task_path: self.task_path,
                     task_owner_path: self.task_owner_path,
                     current_task: None,
+                    current_ip,
                 })
             }
             None => Err("No node URI provided. Please specify a node URI to connect.".into()),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,11 +1,14 @@
-use crate::{error::Result, worker::{CyborgClient, IpResponse, WorkerData}};
-use std::path::PathBuf;
-use subxt::utils::AccountId32;
-use subxt::{OnlineClient, PolkadotConfig};
-use subxt_signer::{SecretUri, sr25519::Keypair as SR25519Keypair};
-use std::str::FromStr;
+use crate::{
+    error::Result,
+    worker::{CyborgClient, IpResponse, WorkerData},
+};
 use pinata_sdk::PinataApi;
 use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+use subxt::utils::AccountId32;
+use subxt::{OnlineClient, PolkadotConfig};
+use subxt_signer::{sr25519::Keypair as SR25519Keypair, SecretUri};
 
 pub struct NoKeypair;
 pub struct AccountKeypair(SR25519Keypair);
@@ -51,7 +54,7 @@ impl<Keypair> CyborgClientBuilder<Keypair> {
     ///
     /// # Arguments
     /// * `url` - A string representing the WebSocket URL of the node.
-    /// 
+    ///
     /// # Returns
     /// A `CyborgClientBuilder` instance with the parachain_url set.
     pub fn parachain_url(mut self, url: String) -> Self {
@@ -66,15 +69,10 @@ impl<Keypair> CyborgClientBuilder<Keypair> {
     ///
     /// # Returns
     /// A `Result` that, if successful, contains a new `CyborgClientBuilder` instance with an `AccountKeypair`.
-    pub fn keypair(
-        self,
-        seed: &str,
-    ) -> Result<CyborgClientBuilder<AccountKeypair>> {
+    pub fn keypair(self, seed: &str) -> Result<CyborgClientBuilder<AccountKeypair>> {
         println!("Keypair: {}", seed);
-        let uri = SecretUri::from_str(seed)
-            .expect("Keypair was not set correctly");
-        let keypair = SR25519Keypair::from_uri(&uri)
-            .expect("Keypair from URI failed");
+        let uri = SecretUri::from_str(seed).expect("Keypair was not set correctly");
+        let keypair = SR25519Keypair::from_uri(&uri).expect("Keypair from URI failed");
 
         Ok(CyborgClientBuilder {
             parachain_url: self.parachain_url,
@@ -98,7 +96,12 @@ impl<Keypair> CyborgClientBuilder<Keypair> {
     ///     
     /// # Returns
     /// A `CyborgClientBuilder` instance with the IPFS URI set.
-    pub async fn ipfs_api(mut self, ipfs_url: Option<String>, ipfs_api_key: Option<String>, ipfs_api_secret: Option<String>) -> Self {
+    pub async fn ipfs_api(
+        mut self,
+        ipfs_url: Option<String>,
+        ipfs_api_key: Option<String>,
+        ipfs_api_secret: Option<String>,
+    ) -> Self {
         let url;
         let key;
         let secret;
@@ -117,7 +120,7 @@ impl<Keypair> CyborgClientBuilder<Keypair> {
                 .expect("Not able to process CYBORG_WORKER_NODE_IPFS_API_KEY environment variable - please check if it is set.");
         }
 
-        if let Some(ipfs_api_secret) = ipfs_api_secret {        
+        if let Some(ipfs_api_secret) = ipfs_api_secret {
             secret = ipfs_api_secret;
         } else {
             secret = env::var("CYBORG_WORKER_NODE_IPFS_API_SECRET")
@@ -128,8 +131,7 @@ impl<Keypair> CyborgClientBuilder<Keypair> {
         println!("IPFS API KEY: {}", key);
         println!("IPFS API SECRET: {}", secret);
 
-        let api = PinataApi::new(key, secret)
-            .expect("Not able to create IPFS API client");
+        let api = PinataApi::new(key, secret).expect("Not able to create IPFS API client");
 
         let result = api.test_authentication().await;
 
@@ -147,7 +149,7 @@ impl<Keypair> CyborgClientBuilder<Keypair> {
     ///
     /// # Arguments
     /// * `config` - A `WorkerData` struct containing the identity and the creator of the worker.
-    /// 
+    ///
     /// # Returns
     /// A `CyborgClientBuilder` instance with the identity and the creator set.
     pub fn config(mut self, config: WorkerData) -> Self {
@@ -163,10 +165,16 @@ impl<Keypair> CyborgClientBuilder<Keypair> {
     /// * `config_path` - A string representing the path to the config file.
     /// * `task_path` - A string representing the path to the task file.
     /// * `task_owner_path` - A string representing the path to the task owner file.
-    /// 
+    ///
     /// # Returns
     /// A `CyborgClientBuilder` instance with the required paths set.
-    pub fn paths(mut self, log_path: String, config_path: String, task_path: String, task_owner_path: String) -> Self {
+    pub fn paths(
+        mut self,
+        log_path: String,
+        config_path: String,
+        task_path: String,
+        task_owner_path: String,
+    ) -> Self {
         self.log_path = PathBuf::from(log_path);
         self.config_path = PathBuf::from(config_path);
         self.task_path = PathBuf::from(task_path);
@@ -187,10 +195,10 @@ impl CyborgClientBuilder<AccountKeypair> {
                 let client = OnlineClient::<PolkadotConfig>::from_url(url).await?;
 
                 let current_ip = reqwest::get("https://api.ipify.org?format=json")
-                .await?
-                .json::<IpResponse>()
-                .await?
-                .ip;
+                    .await?
+                    .json::<IpResponse>()
+                    .await?
+                    .ip;
 
                 Ok(CyborgClient {
                     client,
@@ -219,8 +227,12 @@ mod tests {
     #[tokio::test]
     async fn test_node_uri() {
         // Test setting the node URI in the builder.
-        let builder = CyborgClientBuilder::default().parachain_url("ws://127.0.0.1:9988".to_string());
-        assert_eq!(builder.parachain_url, Some("ws://127.0.0.1:9988".to_string()));
+        let builder =
+            CyborgClientBuilder::default().parachain_url("ws://127.0.0.1:9988".to_string());
+        assert_eq!(
+            builder.parachain_url,
+            Some("ws://127.0.0.1:9988".to_string())
+        );
 
         // Test setting both node URI and keypair.
         let builder = CyborgClientBuilder::default()
@@ -246,7 +258,10 @@ mod tests {
             .expect("keypair was not set correctly")
             .public_key();
 
-        assert_eq!(builder.keypair.0.public_key().to_account_id(), expected_public_key.to_account_id());
+        assert_eq!(
+            builder.keypair.0.public_key().to_account_id(),
+            expected_public_key.to_account_id()
+        );
     }
 
     /* #[tokio::test]
@@ -302,7 +317,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_paths() -> Result<()> {
-
         // Test setting the paths in the builder.
         let builder = CyborgClientBuilder::default()
             .parachain_url("ws://127.0.0.1:9944".to_string())
@@ -317,7 +331,10 @@ mod tests {
         assert_eq!(builder.log_path, PathBuf::from("/tmp/cyborg.log"));
         assert_eq!(builder.config_path, PathBuf::from("/tmp/cyborg.config"));
         assert_eq!(builder.task_path, PathBuf::from("/tmp/cyborg.task"));
-        assert_eq!(builder.task_owner_path, PathBuf::from("/tmp/cyborg.task_owner"));
+        assert_eq!(
+            builder.task_owner_path,
+            PathBuf::from("/tmp/cyborg.task_owner")
+        );
 
         // Test setting the paths without a keypair.
         let builder = CyborgClientBuilder::default()
@@ -332,7 +349,10 @@ mod tests {
         assert_eq!(builder.log_path, PathBuf::from("/tmp/cyborg.log"));
         assert_eq!(builder.config_path, PathBuf::from("/tmp/cyborg.config"));
         assert_eq!(builder.task_path, PathBuf::from("/tmp/cyborg.task"));
-        assert_eq!(builder.task_owner_path, PathBuf::from("/tmp/cyborg.task_owner"));
+        assert_eq!(
+            builder.task_owner_path,
+            PathBuf::from("/tmp/cyborg.task_owner")
+        );
 
         Ok(())
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,7 +54,6 @@ pub enum Commands {
         /// Account ID for the worker registration.
         #[clap(long, value_name = "ACCOUNT_SEED")]
         account_seed: String,
-
         //// IPFS URL for the worker.
         //#[clap(long, value_name = "IPFS_URL")]
         //ipfs_url: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use derive_more::From;
 /// A type alias for a `Result` with the custom error enum `Error`.
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// The custom error enum for the cyborg worker. This error enum covers all of the error variants that can occur, 
+/// The custom error enum for the cyborg worker. This error enum covers all of the error variants that can occur,
 /// enabling all errors to be handled with the `?` operator, but not preventing handling the errors more precisely.
 #[derive(Debug, From)]
 pub enum Error {

--- a/src/specs.rs
+++ b/src/specs.rs
@@ -1,13 +1,12 @@
-use std::{env, str};
-use sysinfo::{System, MemoryRefreshKind, RefreshKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::process::{Command, Stdio};
+use std::{env, str};
+use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 
 use crate::{
-    substrate_interface::api::runtime_types::bounded_collections::bounded_vec::BoundedVec, 
-    worker,
-    error::Result
+    error::Result,
+    substrate_interface::api::runtime_types::bounded_collections::bounded_vec::BoundedVec, worker,
 };
 
 #[derive(Deserialize, Debug)]
@@ -23,9 +22,12 @@ pub struct Location {
 }
 
 pub async fn gather_worker_spec() -> Result<worker::WorkerConfig> {
-
     let response = env::var("CYBORG_WORKER_NODE_TEST_IP").unwrap_or(
-     reqwest::get("https://api.ipify.org?format=json").await?.json::<worker::IpResponse>().await?.ip
+        reqwest::get("https://api.ipify.org?format=json")
+            .await?
+            .json::<worker::IpResponse>()
+            .await?
+            .ip,
     );
 
     //let response = worker::IpResponse { ip: String::from("127.0.0.1") };
@@ -49,27 +51,26 @@ pub async fn gather_worker_spec() -> Result<worker::WorkerConfig> {
 }
 
 fn get_cpu_cores() -> u16 {
-
     let mut sys = System::new_all();
     sys.refresh_all();
 
-    sys.cpus().len() as u16 
+    sys.cpus().len() as u16
 }
 
 impl Location {
     pub async fn get_location() -> Location {
         // Try getting GPS location first
         if let Ok((lat, lon)) = get_gps_location() {
-            return Location{
-                coordinates: f64_to_i32_coordinates(lat, lon)
+            return Location {
+                coordinates: f64_to_i32_coordinates(lat, lon),
             };
         }
-        
+
         if let Ok((lat, lon)) = get_ip_location().await {
             // Fallback to IP-based geolocation
             println!("Failed to get GPS location. Falling back to IP-based geolocation.");
-            return Location{
-                coordinates: f64_to_i32_coordinates(lat, lon)
+            return Location {
+                coordinates: f64_to_i32_coordinates(lat, lon),
             };
         } else {
             panic!("Failed to get the location: Both GPS and IP-based geolocation failed, cannot register worker.");
@@ -87,8 +88,9 @@ fn f64_to_i32_coordinates(lat: f64, lon: f64) -> Coordinates {
 fn get_gps_location() -> Result<(f64, f64)> {
     // Use gpspipe to get single GPS datum
     let output = Command::new("gpspipe")
-        .arg("-w") 
-        .arg("-n").arg("1")
+        .arg("-w")
+        .arg("-n")
+        .arg("1")
         .output()?;
 
     if !output.status.success() {
@@ -118,13 +120,19 @@ async fn get_ip_location() -> Result<(f64, f64)> {
     if response.status().is_success() {
         let ip_info: IpLocation = response.json().await?;
 
-        let loc = ip_info.loc.ok_or_else(|| "Failed to get location via IP.")?;
+        let loc = ip_info
+            .loc
+            .ok_or_else(|| "Failed to get location via IP.")?;
 
         let loc_parts: Vec<&str> = loc.split(',').collect();
-        
+
         if loc_parts.len() == 2 {
-            let lat = loc_parts[0].parse::<f64>().map_err(|_| "Failed to parse latitude")?;
-            let lon = loc_parts[1].parse::<f64>().map_err(|_| "Failed to parse longitude")?;
+            let lat = loc_parts[0]
+                .parse::<f64>()
+                .map_err(|_| "Failed to parse latitude")?;
+            let lon = loc_parts[1]
+                .parse::<f64>()
+                .map_err(|_| "Failed to parse longitude")?;
 
             return Ok((lat, lon));
         }
@@ -158,13 +166,9 @@ pub async fn get_memory() -> Result<String> {
 }
 
 pub fn return_total_memory() -> u64 {
-    let mut system = System::new_with_specifics(
-        RefreshKind::new()
-            .with_memory(MemoryRefreshKind::new())
-    );
+    let mut system =
+        System::new_with_specifics(RefreshKind::new().with_memory(MemoryRefreshKind::new()));
     system.refresh_memory();
-
-
 
     system.total_memory()
 }
@@ -181,15 +185,19 @@ pub fn return_total_storage() -> u64 {
         .expect("Failed to execute command");
 
     // Print the raw command output for debugging
-    println!("Command output: {}", String::from_utf8_lossy(&output.stdout));
+    println!(
+        "Command output: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
 
     let stdout = str::from_utf8(&output.stdout).expect("Invalid UTF-8");
 
     let mut total_space: u64 = 0;
 
-    for line in stdout.lines().skip(1) {  // Skip the header line
+    for line in stdout.lines().skip(1) {
+        // Skip the header line
         let parts: Vec<&str> = line.split_whitespace().collect();
-        
+
         // Check if the first column (filesystem) starts with "/dev/"
         if let Some(filesystem) = parts.get(0) {
             if filesystem.starts_with("/dev/") {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,2 @@
-pub mod substrate_transactions;
 pub mod substrate_queries;
+pub mod substrate_transactions;

--- a/src/utils/substrate_queries.rs
+++ b/src/utils/substrate_queries.rs
@@ -1,6 +1,6 @@
-use subxt::{OnlineClient, PolkadotConfig};
-use crate::{substrate_interface, error::Result};
+use crate::{error::Result, substrate_interface};
 use subxt::utils::AccountId32;
+use subxt::{OnlineClient, PolkadotConfig};
 
 // Struct that contains the data that the worker needs to execute a task
 pub struct CyborgTask {
@@ -10,8 +10,9 @@ pub struct CyborgTask {
 }
 
 pub async fn get_task(api: &OnlineClient<PolkadotConfig>, task_id: u64) -> Result<CyborgTask> {
-    let task_address = 
-        substrate_interface::api::storage().task_management().tasks(task_id);
+    let task_address = substrate_interface::api::storage()
+        .task_management()
+        .tasks(task_id);
 
     let task_query = api
         .storage()
@@ -23,13 +24,11 @@ pub async fn get_task(api: &OnlineClient<PolkadotConfig>, task_id: u64) -> Resul
     if let Some(task) = task_query {
         let ipfs_cid_string = String::from_utf8(task.metadata.0)?;
 
-        Ok(
-            CyborgTask{
-                id: task_id,
-                owner: task.task_owner,
-                cid: ipfs_cid_string,
-            }
-        )
+        Ok(CyborgTask {
+            id: task_id,
+            owner: task.task_owner,
+            cid: ipfs_cid_string,
+        })
     } else {
         Err("Task not found".into())
     }

--- a/src/utils/substrate_transactions.rs
+++ b/src/utils/substrate_transactions.rs
@@ -1,11 +1,11 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
+use subxt::utils::H256;
 use subxt::{OnlineClient, PolkadotConfig};
 use subxt_signer::sr25519::Keypair;
-use subxt::utils::H256;
 
+use crate::{error::Result, substrate_interface};
 use substrate_interface::api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
-use crate::{substrate_interface, error::Result};
 
 #[derive(Debug)]
 pub enum TransactionType {
@@ -109,7 +109,14 @@ impl TransactionQueue {
                     task_id,
                     retry_count,
                 } => {
-                    let result = submit_result_internal(api, signer_keypair, completed_hash, result_cid.clone(), task_id).await;
+                    let result = submit_result_internal(
+                        api,
+                        signer_keypair,
+                        completed_hash,
+                        result_cid.clone(),
+                        task_id,
+                    )
+                    .await;
                     (result, completed_hash, task_id, retry_count)
                 }
                 Transaction::SubmitResultVerification {
@@ -117,7 +124,13 @@ impl TransactionQueue {
                     task_id,
                     retry_count,
                 } => {
-                    let result = submit_result_verification_internal(api, signer_keypair, completed_hash, task_id).await;
+                    let result = submit_result_verification_internal(
+                        api,
+                        signer_keypair,
+                        completed_hash,
+                        task_id,
+                    )
+                    .await;
                     (result, completed_hash, task_id, retry_count)
                 }
                 Transaction::SubmitResultResolution {
@@ -125,49 +138,62 @@ impl TransactionQueue {
                     task_id,
                     retry_count,
                 } => {
-                    let result = submit_result_resolution_internal(api, signer_keypair, completed_hash, task_id).await;
+                    let result = submit_result_resolution_internal(
+                        api,
+                        signer_keypair,
+                        completed_hash,
+                        task_id,
+                    )
+                    .await;
                     (result, completed_hash, task_id, retry_count)
                 }
             };
 
             match result {
                 (Ok(_), _, _, _) => Ok(()),
-                (Err(e), _completed_hash,_task_idd, retry_count) => {
+                (Err(e), _completed_hash, _task_idd, retry_count) => {
                     if Self::is_nonce_error(&e) {
                         let delay_ms = std::cmp::min(
                             10_000,
-                            RETRY_DELAY_MS * 2u64.pow(std::cmp::min(retry_count as u32, 10)), 
+                            RETRY_DELAY_MS * 2u64.pow(std::cmp::min(retry_count as u32, 10)),
                         );
-                        
+
                         println!("Nonce error detected, retrying transaction (attempt {}). Sleeping for {}ms...", 
                             retry_count + 1, delay_ms);
-                        
+
                         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                        
+
                         let mut queue = self.inner.lock().unwrap();
                         let new_transaction = match transaction {
-                            Transaction::SubmitResult { completed_hash, result_cid, task_id, .. } => {
-                                Transaction::SubmitResult {
-                                    completed_hash,
-                                    result_cid,
-                                    task_id,
-                                    retry_count: retry_count + 1,
-                                }
-                            }
-                            Transaction::SubmitResultVerification { completed_hash, task_id, .. } => {
-                                Transaction::SubmitResultVerification {
-                                    completed_hash,
-                                    task_id,
-                                    retry_count: retry_count + 1,
-                                }
-                            }
-                            Transaction::SubmitResultResolution { completed_hash, task_id, .. } => {
-                                Transaction::SubmitResultResolution {
-                                    completed_hash,
-                                    task_id,
-                                    retry_count: retry_count + 1,
-                                }
-                            }
+                            Transaction::SubmitResult {
+                                completed_hash,
+                                result_cid,
+                                task_id,
+                                ..
+                            } => Transaction::SubmitResult {
+                                completed_hash,
+                                result_cid,
+                                task_id,
+                                retry_count: retry_count + 1,
+                            },
+                            Transaction::SubmitResultVerification {
+                                completed_hash,
+                                task_id,
+                                ..
+                            } => Transaction::SubmitResultVerification {
+                                completed_hash,
+                                task_id,
+                                retry_count: retry_count + 1,
+                            },
+                            Transaction::SubmitResultResolution {
+                                completed_hash,
+                                task_id,
+                                ..
+                            } => Transaction::SubmitResultResolution {
+                                completed_hash,
+                                task_id,
+                                retry_count: retry_count + 1,
+                            },
                         };
                         queue.push_front(new_transaction);
                         Ok(())
@@ -185,8 +211,8 @@ impl TransactionQueue {
     }
 
     fn is_nonce_error(error: &crate::error::Error) -> bool {
-        error.to_string().contains("InvalidTransaction") && 
-            (error.to_string().contains("Stale") || error.to_string().contains("nonce"))
+        error.to_string().contains("InvalidTransaction")
+            && (error.to_string().contains("Stale") || error.to_string().contains("nonce"))
     }
 }
 
@@ -195,19 +221,15 @@ lazy_static::lazy_static! {
 }
 
 async fn submit_result_internal(
-    api: &OnlineClient<PolkadotConfig>, 
-    signer_keypair: &Keypair, 
+    api: &OnlineClient<PolkadotConfig>,
+    signer_keypair: &Keypair,
     completed_hash: H256,
     result_cid: BoundedVec<u8>,
-    task_id: u64, 
+    task_id: u64,
 ) -> Result<()> {
     let result_submission_tx = substrate_interface::api::tx()
         .task_management()
-        .submit_completed_task(
-            task_id, 
-            completed_hash, 
-            result_cid.clone(), 
-        );
+        .submit_completed_task(task_id, completed_hash, result_cid.clone());
 
     println!("Transaction Details:");
     println!("Module: {:?}", result_submission_tx.pallet_name());
@@ -225,8 +247,7 @@ async fn submit_result_internal(
         .wait_for_finalized_success()
         .await?;
 
-    let submission_event = 
-        result_submission_events.find_first::<substrate_interface::api::task_management::events::SubmittedCompletedTask>()?;
+    let submission_event = result_submission_events.find_first::<substrate_interface::api::task_management::events::SubmittedCompletedTask>()?;
     if let Some(event) = submission_event {
         println!("Task submitted successfully: {event:?}");
     } else {
@@ -237,17 +258,14 @@ async fn submit_result_internal(
 }
 
 async fn submit_result_verification_internal(
-    api: &OnlineClient<PolkadotConfig>, 
-    signer_keypair: &Keypair, 
+    api: &OnlineClient<PolkadotConfig>,
+    signer_keypair: &Keypair,
     completed_hash: H256,
-    task_id: u64, 
+    task_id: u64,
 ) -> Result<()> {
     let verification_submission_tx = substrate_interface::api::tx()
         .task_management()
-        .verify_completed_task(
-            task_id, 
-            completed_hash
-        );
+        .verify_completed_task(task_id, completed_hash);
 
     println!("Transaction Details:");
     println!("Module: {:?}", verification_submission_tx.pallet_name());
@@ -265,8 +283,7 @@ async fn submit_result_verification_internal(
         .wait_for_finalized_success()
         .await?;
 
-    let submission_event = 
-        verification_submission_events.find_first::<substrate_interface::api::task_management::events::VerifiedCompletedTask>()?;
+    let submission_event = verification_submission_events.find_first::<substrate_interface::api::task_management::events::VerifiedCompletedTask>()?;
     if let Some(event) = submission_event {
         println!("Task submitted successfully: {event:?}");
     } else {
@@ -277,17 +294,14 @@ async fn submit_result_verification_internal(
 }
 
 async fn submit_result_resolution_internal(
-    api: &OnlineClient<PolkadotConfig>, 
-    signer_keypair: &Keypair, 
+    api: &OnlineClient<PolkadotConfig>,
+    signer_keypair: &Keypair,
     completed_hash: H256,
-    task_id: u64, 
+    task_id: u64,
 ) -> Result<()> {
     let resolution_submission_tx = substrate_interface::api::tx()
         .task_management()
-        .resolve_completed_task(
-            task_id, 
-            completed_hash
-        );
+        .resolve_completed_task(task_id, completed_hash);
 
     println!("Transaction Details:");
     println!("Module: {:?}", resolution_submission_tx.pallet_name());
@@ -305,8 +319,7 @@ async fn submit_result_resolution_internal(
         .wait_for_finalized_success()
         .await?;
 
-    let submission_event = 
-        resolution_submission_events.find_first::<substrate_interface::api::task_management::events::ResolvedCompletedTask>()?;
+    let submission_event = resolution_submission_events.find_first::<substrate_interface::api::task_management::events::ResolvedCompletedTask>()?;
     if let Some(event) = submission_event {
         println!("Task submitted successfully: {event:?}");
     } else {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -299,8 +299,6 @@ impl BlockchainClient for CyborgClient {
         Ok(())
     }
 
-
-
     /// Starts a mining session by subscribing to finalized blocks and listening for events.
     ///
     /// # Returns

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -234,7 +234,6 @@ impl CyborgClient {
 
     #[allow(dead_code)]
     async fn handle_ip_change(&self) -> Result<()> {
-        // Stop mining by returning an error that will break the mining loop
         Err(Error::Custom("IP address changed - stopping worker".into()))
     }
 }
@@ -300,16 +299,7 @@ impl BlockchainClient for CyborgClient {
         Ok(())
     }
 
-    // for event in events.iter() {
-    //     match event {
-    //         Ok(ev) => {
-    //             if let Err(e) = self.process_event(&ev).await {
-    //                 println!("Error processing event: {:?}", e);
-    //             }
-    //         }
-    //         Err(e) => eprintln!("Error decoding event: {:?}", e),
-    //     }
-    // }
+
 
     /// Starts a mining session by subscribing to finalized blocks and listening for events.
     ///
@@ -330,7 +320,6 @@ impl BlockchainClient for CyborgClient {
 
         loop {
             tokio::select! {
-                // IP check branch
                 _ = ip_check_interval.tick() => {
                     match self.check_ip_change().await {
                         Ok(true) => {
@@ -339,16 +328,13 @@ impl BlockchainClient for CyborgClient {
                             return Err(Error::Custom("IP address changed - stopping worker".into()));
                         }
                         Ok(false) => {
-                            // IP unchanged, continue mining
                         }
                         Err(e) => {
                             self.write_log(&format!("Error checking IP address: {}", e));
-                            // Continue mining despite IP check failure
                         }
                     }
                 }
 
-                // Transaction processing branch
                 _ = async {
                     if let Err(e) = crate::utils::substrate_transactions::process_transactions(
                         &self.client,
@@ -361,7 +347,6 @@ impl BlockchainClient for CyborgClient {
                     }
                 } => {}
 
-                // Block processing branch
                 block = blocks.next() => {
                     match block {
                         Some(Ok(block)) => {


### PR DESCRIPTION
This PR adds IP address change detection to worker nodes with the following behavior:

- Workers periodically check their public IP (every 60 seconds)

- If the IP changes, the worker automatically stops mining

- Comprehensive logging of IP changes and worker status

- The oracle feeder will detect inactive workers and prompt users to update information