### PR TITLE
Add model decryption support using DH key exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3268,6 +3268,7 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.9.1",
  "reqwest 0.12.19",
+ "schnorrkel",
  "serde",
  "serde_json",
  "sp-api 33.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,6 +3241,7 @@ dependencies = [
 name = "cyborg-miner"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "async-stream",
  "async-trait 0.1.88 (git+https://github.com/dtolnay/async-trait.git)",
  "axum",
@@ -3265,6 +3266,7 @@ dependencies = [
  "once_cell",
  "open-inference-runtime",
  "parity-scale-codec",
+ "rand 0.9.1",
  "reqwest 0.12.19",
  "serde",
  "serde_json",
@@ -3281,6 +3283,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber 0.3.19",
  "url",
+ "x25519-dalek",
  "zbus",
  "zbus_names",
  "zip 2.4.2",

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -57,6 +57,9 @@ zbus = "5.1.1"
 zbus_names = "4.1.0"
 zip = "2.2.0"
 lazy_static = "1.5.0"
+x25519-dalek = "2.0.1"
+aes-gcm = "0.10.3"
+rand = "0.9.1"
 
 [build-dependencies]
 

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -40,6 +40,7 @@ docify = { version = "0.2.8" }
 dotenv = "0.15.0"
 once_cell = "1.21.3"
 fs2 = "0.4.3"
+schnorrkel = "0.11"
 futures-util = "0.3.31"
 hex = { version = "0.4.3" } 
 jsonrpsee = { version = "0.22", features = ["server"] }

--- a/miner/src/builder.rs
+++ b/miner/src/builder.rs
@@ -3,9 +3,9 @@ use crate::{
     error::Result,
     types::{AccountKeypair, Miner, MinerData, ParentRuntime},
 };
-use std::{fs, str::FromStr, sync::Arc};
+use std::{fs, sync::Arc};
 use subxt::utils::AccountId32;
-use subxt_signer::{sr25519::Keypair as SR25519Keypair, SecretUri};
+use subxt_signer::{sr25519::Keypair as SR25519Keypair};
 use tokio::sync::RwLock;
 use tracing::warn;
 
@@ -86,7 +86,7 @@ impl<Keypair> MinerBuilder<Keypair> {
                     identity = Some(config.miner_identity.clone());
                     creator = Some(config.miner_identity.0);
                 }
-                Err(e) => {
+                Err(_e) => {
                     warn!("No miner identity present, identity will be set when registering...")
                 }
             }

--- a/miner/src/config.rs
+++ b/miner/src/config.rs
@@ -14,10 +14,10 @@ use crate::utils::tx_queue::TransactionQueue;
 use crate::utils::tx_queue::TRANSACTION_QUEUE;
 
 //TODO put this in evironment variables
-const LOG_PATH: &str = "/var/lib/cyborg/worker-node/logs/worker_log.txt";
-const TASK_PATH: &str = "/var/lib/cyborg/worker-node/task/current_task";
-const TASK_OWNER_PATH: &str = "/var/lib/cyborg/worker-node/task/task_owner.json";
-const IDENTITY_PATH: &str = "/var/lib/cyborg/worker-node/identity.json";
+// const LOG_PATH: &str = "/var/lib/cyborg/worker-node/logs/worker_log.txt";
+// const TASK_PATH: &str = "/var/lib/cyborg/worker-node/task/current_task";
+// const TASK_OWNER_PATH: &str = "/var/lib/cyborg/worker-node/task/task_owner.json";
+// const IDENTITY_PATH: &str = "/var/lib/cyborg/worker-node/identity.json";
 
 #[derive(Debug)]
 pub struct Paths {
@@ -29,6 +29,7 @@ pub struct Paths {
 }
 
 #[derive(Deserialize, Debug)]
+#[allow(dead_code)]
 struct MinerIdentity {
     owner: AccountId32,
     id: u32,
@@ -46,7 +47,7 @@ pub static CESS_GATEWAY: Lazy<Arc<RwLock<String>>> =
 /// # Arguments
 /// * `parachain_url` - A string representing the URL of the parachain node to connect to.
 /// * `account_seed` - A string representing the seed phrase for generating the keypair.
-pub async fn run_config(parachain_url: &str, account: Keypair) {
+pub async fn run_config(parachain_url: &str, _account: Keypair) {
     dotenv::dotenv().ok();
 
     let storage_location = String::from(env::var("STORAGE_LOCATION").expect("STORAGE_LOCATION must be set"));
@@ -115,10 +116,11 @@ pub fn get_paths() -> Result<&'static Paths> {
     PATHS.get().ok_or(Error::config_paths_not_initialized())
 }
 
+#[allow(dead_code)]
 pub async fn get_cess_gateway() -> String {
     CESS_GATEWAY.read().await.clone()
 }
-
+#[allow(dead_code)]
 pub async fn set_cess_gateway(url: &str) {
     let mut write_guard = CESS_GATEWAY.write().await;
 

--- a/miner/src/crypto/aes.rs
+++ b/miner/src/crypto/aes.rs
@@ -1,0 +1,53 @@
+use aes_gcm::{
+    aead::{rand_core::RngCore, Aead, KeyInit, OsRng},
+    Aes256Gcm, Nonce
+};
+use aes_gcm::aead::generic_array::GenericArray;
+// use rand::RngCore;
+use crate::error::Error;
+
+/// Encrypts data using AES-256-GCM
+/// 
+/// # Arguments
+/// * `data` - Plaintext data to encrypt
+/// * `key` - 32-byte encryption key
+/// 
+/// # Returns
+/// Combined ciphertext + nonce (nonce is last 12 bytes)
+pub fn encrypt(data: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, Error> {
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| Error::Custom(format!("Key initialization failed: {}", e)))?;
+    
+    // Generate random nonce
+    let mut nonce = [0u8; 12];
+    OsRng.fill_bytes(&mut nonce);
+    let nonce = Nonce::from_slice(&nonce);
+    
+    cipher.encrypt(nonce, data)
+        .map(|mut ciphertext| {
+            ciphertext.extend_from_slice(nonce);
+            ciphertext
+        })
+        .map_err(|e| Error::Custom(format!("Encryption failed: {}", e)))
+}
+
+/// Decrypts data using AES-256-GCM
+/// 
+/// # Arguments
+/// * `data` - Ciphertext with appended nonce (last 12 bytes)
+/// * `key` - 32-byte decryption key
+/// 
+/// # Returns
+/// Decrypted plaintext data
+pub fn decrypt(data: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, Error> {
+    if data.len() < 12 {
+        return Err(Error::Custom("Ciphertext too short".into()));
+    }
+    
+    let (ciphertext, nonce) = data.split_at(data.len() - 12);
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| Error::Custom(format!("Key initialization failed: {}", e)))?;
+    let nonce = GenericArray::from_slice(nonce);
+    cipher.decrypt(nonce, ciphertext)
+        .map_err(|e| Error::Custom(format!("Decryption failed: {}", e)))
+}

--- a/miner/src/crypto/dhx.rs
+++ b/miner/src/crypto/dhx.rs
@@ -1,0 +1,25 @@
+use x25519_dalek::{EphemeralSecret, PublicKey};
+use subxt_signer::sr25519::Keypair;
+
+pub struct MinerDH {
+    secret: EphemeralSecret,
+    pub public: PublicKey,
+}
+
+impl MinerDH {
+    pub fn new(keypair: &Keypair) -> Self {
+        // Convert sr25519 secret key to x25519
+        let secret_bytes = keypair.into_raw().secret_key.to_bytes();
+        let secret = EphemeralSecret::from(secret_bytes);
+        let public = PublicKey::from(&secret);
+        Self { secret, public }
+    }
+
+    pub fn derive_shared_secret(self, gatekeeper_pub: PublicKey) -> [u8; 32] {
+        *self.secret.diffie_hellman(&gatekeeper_pub).as_bytes()
+    }
+
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.public.to_bytes()
+    }
+}

--- a/miner/src/crypto/dhx.rs
+++ b/miner/src/crypto/dhx.rs
@@ -9,7 +9,7 @@ pub struct MinerDH {
 impl MinerDH {
     pub fn new(keypair: &Keypair) -> Self {
         // Convert sr25519 secret key to x25519
-        let secret_bytes = keypair.into_raw().secret_key.to_bytes();
+        let secret_bytes = keypair.0.secret.to_bytes();
         let secret = EphemeralSecret::from(secret_bytes);
         let public = PublicKey::from(&secret);
         Self { secret, public }

--- a/miner/src/crypto/mod.rs
+++ b/miner/src/crypto/mod.rs
@@ -1,0 +1,2 @@
+pub mod aes;
+pub mod dhx;

--- a/miner/src/error.rs
+++ b/miner/src/error.rs
@@ -6,6 +6,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// The custom error enum for the cyborg worker. This error enum covers all of the error variants that can occur,
 /// enabling all errors to be handled with the `?` operator, but not preventing handling the errors more precisely.
 #[derive(Debug, From)]
+#[allow(dead_code)]
 pub enum Error {
     #[from]
     Custom(String),
@@ -30,6 +31,7 @@ pub enum Error {
     Cess(cess_rust_sdk::core::Error),
 }
 
+#[allow(dead_code)]
 impl Error {
     pub fn custom(val: impl std::fmt::Display) -> Self {
         Self::Custom(val.to_string())

--- a/miner/src/log.rs
+++ b/miner/src/log.rs
@@ -21,6 +21,7 @@ pub fn init_logger() {
     *LOG_GUARD.lock().unwrap() = Some(guard);
 }
 
+#[allow(dead_code)]
 fn reset_log_file() -> Result<()> {
     *LOG_GUARD.lock().unwrap() = None;
 

--- a/miner/src/main.rs
+++ b/miner/src/main.rs
@@ -24,6 +24,7 @@ mod substrate_interface;
 mod traits;
 mod types;
 mod utils;
+mod crypto;
 
 use builder::MinerBuilder;
 use clap::Parser;

--- a/miner/src/parachain_interactor/event_processor.rs
+++ b/miner/src/parachain_interactor/event_processor.rs
@@ -119,7 +119,7 @@ pub async fn process_event(miner: &mut Miner, event: &EventDetails<PolkadotConfi
                         if let Err(e) = parent_runtime_clone
                             .read()
                             .await
-                            .download_model_archive(&task_fid_string, storage_encryption_cipher)
+                            .download_model_archive(&task_fid_string, storage_encryption_cipher, &keypair_clone)
                             .await
                         {
                             println!("Error downloading model archive: {}", e);

--- a/miner/src/parachain_interactor/registration.rs
+++ b/miner/src/parachain_interactor/registration.rs
@@ -10,6 +10,7 @@ use std::fs;
 use subxt::utils::AccountId32;
 
 #[derive(Deserialize)]
+#[allow(dead_code)]
 struct Identity {
     miner_owner: String,
     miner_identity: (AccountId32, u64),

--- a/miner/src/parent_runtime/inference.rs
+++ b/miner/src/parent_runtime/inference.rs
@@ -32,6 +32,7 @@ pub enum InferenceEngine {
 }
 
 #[derive(Clone)]
+#[allow(dead_code)]
 struct AppState {
     task: CurrentTask,
     engine: InferenceEngine,
@@ -117,7 +118,7 @@ pub async fn spawn_inference_server(
             let _ = status_tx.send(EngineStatus::Initializing);
 
             match &engine {
-                InferenceEngine::OpenInference(client) => {
+                InferenceEngine::OpenInference(_client) => {
                     let _ = status_tx.send(EngineStatus::Ready);
 
                 }

--- a/miner/src/parent_runtime/storage_interactor.rs
+++ b/miner/src/parent_runtime/storage_interactor.rs
@@ -8,7 +8,6 @@ use crate::error::{Error, Result};
 //use cess_rust_sdk::utils::str::get_random_code;
 //use tracing::info;
 use crate::crypto::aes::decrypt;
-use aes_gcm::aead::generic_array::GenericArray;
 use futures_util::StreamExt;
 use reqwest::Client;
 use std::fs;
@@ -112,7 +111,10 @@ pub async fn download_model_archive(
     }
 
     let miner_dh = MinerDH::new(keypair);
-    let gatekeeper_pub = PublicKey::from(*GenericArray::from_slice(cipher.as_bytes()));
+    let cipher_bytes: [u8; 32] = cipher.as_bytes()[..32]
+        .try_into()
+        .expect("Cipher must be 32 bytes");
+    let gatekeeper_pub = PublicKey::from(cipher_bytes);
 
     let shared_secret = miner_dh.derive_shared_secret(gatekeeper_pub);
 

--- a/miner/src/parent_runtime/storage_interactor.rs
+++ b/miner/src/parent_runtime/storage_interactor.rs
@@ -1,4 +1,5 @@
-use crate::config::{self/* , CESS_GATEWAY*/, PATHS};
+use crate::config::{self /* , CESS_GATEWAY*/, PATHS};
+use crate::crypto::dhx::MinerDH;
 use crate::error::{Error, Result};
 //use cess_rust_sdk::gateway::file::{download, download_encrypt};
 //use cess_rust_sdk::polkadot::runtime_apis::asset_conversion_api::types::get_reserves::output;
@@ -6,15 +7,19 @@ use crate::error::{Error, Result};
 //use cess_rust_sdk::utils::account::get_pair_address_as_ss58_address;
 //use cess_rust_sdk::utils::str::get_random_code;
 //use tracing::info;
+use crate::crypto::aes::decrypt;
+use aes_gcm::aead::generic_array::GenericArray;
 use futures_util::StreamExt;
 use reqwest::Client;
+use std::fs;
 use std::path::Path;
+use subxt_signer::sr25519::Keypair;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
-use std::fs;
+use x25519_dalek::PublicKey;
 
 // This is currently out of use until CESS is fixed
-/* 
+/*
 pub async fn download_model_archive(cess_fid: &str, cipher: &str) -> Result<()> {
     //! The extraction of the archive will be left up to the individual runtimes, as they might treat it differently
     println!("Starting download model archive: {}", cess_fid);
@@ -55,12 +60,15 @@ pub async fn download_model_archive(cess_fid: &str, cipher: &str) -> Result<()> 
 
     Ok(())
 }
-*/ 
+*/
 
-pub async fn download_model_archive(storage_identifier: &str, _cipher: &str) -> Result<()> {
+pub async fn download_model_archive(
+    storage_identifier: &str,
+    cipher: &str,
+    keypair: &Keypair,
+) -> Result<()> {
     let (task_file_name, task_dir_path) = {
-        let paths = &PATHS.get()
-        .ok_or(Error::config_paths_not_initialized())?;
+        let paths = &PATHS.get().ok_or(Error::config_paths_not_initialized())?;
 
         (&paths.task_file_name, &paths.task_dir_path)
     };
@@ -69,39 +77,51 @@ pub async fn download_model_archive(storage_identifier: &str, _cipher: &str) -> 
     let base_storage_location = config::get_storage_location()?;
     let blob_url = format!("{}/{}", base_storage_location, storage_identifier);
     println!("Downloading model archive from: {}", blob_url);
-    
+
     let output_path = format!("{}/{}", task_dir_path, task_file_name);
     println!("Saving model archive to: {}", output_path);
 
     let client = Client::new();
-    let response = client
-        .get(blob_url)
-        .send()
-        .await?;
+    let response = client.get(blob_url).send().await?;
 
     if !response.status().is_success() {
-        return Err(Error::Custom(format!("Failed to download blob: {}", response.status())));
+        return Err(Error::Custom(format!(
+            "Failed to download blob: {}",
+            response.status()
+        )));
     }
 
     if !fs::metadata(&task_dir_path).is_ok() {
-        return Err(Error::Custom(format!("Directory does not exist: {}", task_dir_path)));
+        return Err(Error::Custom(format!(
+            "Directory does not exist: {}",
+            task_dir_path
+        )));
     }
 
     let mut stream = response.bytes_stream();
     let file_path = Path::new(&output_path);
 
     println!("File path: {}", file_path.display());
-    let mut file = File::create(&file_path)
-        .await?;
+    let mut file = File::create(&file_path).await?;
 
     tracing::info!("Starting model download...");
 
     while let Some(chunk_result) = stream.next().await {
         let chunk = chunk_result?;
-        file.write_all(&chunk)
-            .await?
+        file.write_all(&chunk).await?
     }
 
-    tracing::info!("✅ Model successfully retrieved!");
+    let miner_dh = MinerDH::new(keypair);
+    let gatekeeper_pub = PublicKey::from(*GenericArray::from_slice(cipher.as_bytes()));
+
+    let shared_secret = miner_dh.derive_shared_secret(gatekeeper_pub);
+
+    let encrypted_data = std::fs::read(&output_path)?;
+    let decrypted_data = decrypt(&encrypted_data, &shared_secret)
+        .map_err(|e| Error::Custom(format!("Decryption failed: {}", e)))?;
+
+    std::fs::write(&output_path, decrypted_data)?;
+
+    tracing::info!("✅ Model successfully retrieved and decrypted!");
     Ok(())
 }

--- a/miner/src/specs.rs
+++ b/miner/src/specs.rs
@@ -6,7 +6,6 @@ use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 
 use crate::{
     error::Result,
-    substrate_interface::api::runtime_types::bounded_collections::bounded_vec::BoundedVec,
     types::{IpResponse, MinerConfig},
 };
 

--- a/miner/src/traits.rs
+++ b/miner/src/traits.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 
 use crate::{
     error::Result,
@@ -39,12 +38,14 @@ pub trait InferenceServer {
     /// # Returns
     /// A `Result` containing a vector of bytes representing the proof.
     async fn generate_proof(&self) -> Result<Vec<u8>>;
+    // async fn download_model_archive(&self, fid: &str, gatekeeper_pubkey: &str) -> Result<()>;
+
 }
 
 #[async_trait]
 impl InferenceServer for ParentRuntime {
-    async fn download_model_archive(&self, cess_fid: &str, cipher: &str) -> Result<()> {
-        storage_interactor::download_model_archive(cess_fid, cipher).await
+    async fn download_model_archive(&self, cess_fid: &str, cipher: &str, keypair: &Keypair) -> Result<()> {
+        storage_interactor::download_model_archive(cess_fid, cipher, keypair).await
     }
 
     async fn spawn_inference_server(&self, current_task: &CurrentTask, keypair: &Keypair) -> Result<JoinHandle<()>> {
@@ -95,6 +96,8 @@ pub trait ParachainInteractor {
     ///
     /// # Returns
     /// A `Result` indicating `Ok(())` if the miner is successfully suspended, or an `Error` if it fails.
+#[allow(dead_code)]
+
     async fn suspend_miner(&self) -> Result<()>;
 }
 

--- a/miner/src/traits.rs
+++ b/miner/src/traits.rs
@@ -22,7 +22,7 @@ pub trait InferenceServer {
     ///
     /// # Returns
     /// A `Result` containing `Ok(())` if the model archive is successfully downloaded, or an `Error` if it fails.
-    async fn download_model_archive(&self, fid: &str, cipher: &str) -> Result<()>;
+    async fn download_model_archive(&self, fid: &str, cipher: &str, keypair: &Keypair) -> Result<()>;
 
     /// Starts performing inference, selecting the correct inference engine based on the task type
     ///

--- a/miner/src/types.rs
+++ b/miner/src/types.rs
@@ -1,4 +1,3 @@
-use crate::substrate_interface::api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
 use codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -20,6 +19,7 @@ pub struct CurrentTask {
 }
 
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub enum TaskType {
     OpenInference,
     NeuroZk,
@@ -49,6 +49,8 @@ pub struct AccountKeypair(pub Keypair);
 /// Represents a client for interacting with the Cyborg parachain.
 ///
 /// This struct is used to interact with the Cyborg parachain, manage key pairs
+#[allow(dead_code)]
+
 pub struct Miner {
     // Some fields wrapped in an Arc to eg. keep extraction out of an RwLock before await cheap
     pub(crate) keypair: Keypair,

--- a/miner/src/utils/substrate_queries.rs
+++ b/miner/src/utils/substrate_queries.rs
@@ -3,12 +3,14 @@ use subxt::utils::AccountId32;
 use subxt::{OnlineClient, PolkadotConfig};
 
 // Struct that contains the data that the worker needs to execute a task
+#[allow(dead_code)]
 pub struct CyborgTask {
     pub id: u64,
     pub owner: AccountId32,
     pub cid: String,
 }
 
+#[allow(dead_code)]
 pub async fn get_task(api: &OnlineClient<PolkadotConfig>, task_id: u64) -> Result<CyborgTask> {
     let task_address = substrate_interface::api::storage()
         .task_management()

--- a/miner/src/utils/tx_queue.rs
+++ b/miner/src/utils/tx_queue.rs
@@ -30,6 +30,7 @@ pub struct Transaction {
     retry_count: u32,
 }
 
+#[allow(dead_code)]
 impl Transaction {
     fn new(executor: TxExecutor, responder: Option<oneshot::Sender<Result<TxOutput>>>) -> Self {
         Self {

--- a/neuro-zk-runtime/src/lib.rs
+++ b/neuro-zk-runtime/src/lib.rs
@@ -22,7 +22,7 @@ const MODEL_PATH: &str = "network.ezkl";
 const SETTINGS_PATH: &str = "settings.json";
 const PROVING_KEY_PATH: &str = "pk.key";
 const PROOF_INPUT_PATH: &str = "input.json";
-const PROOF_WITNESS_PATH: &str = "proof-witness.json";
+// const PROOF_WITNESS_PATH: &str = "proof-witness.json";
 const WITNESS_PATH: &str = "witness.json";
 const SRS_PATH: &str = "kzg.srs";
 
@@ -314,8 +314,8 @@ impl NeuroZKEngine {
         input_data: String,
     ) -> Result<String, Box<dyn std::error::Error>> {
         let model_path = PathBuf::from(format!("{}/{}", prefix, model_path));
-        let srs_path = PathBuf::from(format!("{}/{}", prefix, srs_path));
-        let witness_path = PathBuf::from(format!("{}/{}", prefix, witness_path));
+        let _srs_path = PathBuf::from(format!("{}/{}", prefix, srs_path));
+        let _witness_path = PathBuf::from(format!("{}/{}", prefix, witness_path));
 
         println!("Generating inference result for: {}", input_data);
 


### PR DESCRIPTION
This PR adds support for decrypting models received from gatekeepers:

- Implemented DH key exchange using miner's SR25519 key

- Added AES-256-GCM decryption capability

- Modified model download flow to handle decryption

- Added proper error handling for crypto operations

- Ensured secure key derivation