### PR TITLE
feat: Immediately confirm task reception on assignment

### DIFF
--- a/miner/src/builder.rs
+++ b/miner/src/builder.rs
@@ -3,9 +3,9 @@ use crate::{
     error::Result,
     types::{AccountKeypair, Miner, MinerData, ParentRuntime},
 };
-use std::{fs, str::FromStr, sync::Arc};
+use std::{fs, /* str::FromStr, */ sync::Arc};
 use subxt::utils::AccountId32;
-use subxt_signer::{sr25519::Keypair as SR25519Keypair, SecretUri};
+use subxt_signer::{sr25519::Keypair as SR25519Keypair, /*SecretUri*/};
 use tokio::sync::RwLock;
 use tracing::warn;
 
@@ -86,7 +86,7 @@ impl<Keypair> MinerBuilder<Keypair> {
                     identity = Some(config.miner_identity.clone());
                     creator = Some(config.miner_identity.0);
                 }
-                Err(e) => {
+                Err(_e) => {
                     warn!("No miner identity present, identity will be set when registering...")
                 }
             }

--- a/miner/src/config.rs
+++ b/miner/src/config.rs
@@ -14,10 +14,10 @@ use crate::utils::tx_queue::TransactionQueue;
 use crate::utils::tx_queue::TRANSACTION_QUEUE;
 
 //TODO put this in evironment variables
-const LOG_PATH: &str = "/var/lib/cyborg/worker-node/logs/worker_log.txt";
-const TASK_PATH: &str = "/var/lib/cyborg/worker-node/task/current_task";
-const TASK_OWNER_PATH: &str = "/var/lib/cyborg/worker-node/task/task_owner.json";
-const IDENTITY_PATH: &str = "/var/lib/cyborg/worker-node/identity.json";
+// const LOG_PATH: &str = "/var/lib/cyborg/worker-node/logs/worker_log.txt";
+// const TASK_PATH: &str = "/var/lib/cyborg/worker-node/task/current_task";
+// const TASK_OWNER_PATH: &str = "/var/lib/cyborg/worker-node/task/task_owner.json";
+// const IDENTITY_PATH: &str = "/var/lib/cyborg/worker-node/identity.json";
 
 #[derive(Debug)]
 pub struct Paths {
@@ -29,6 +29,7 @@ pub struct Paths {
 }
 
 #[derive(Deserialize, Debug)]
+#[allow(dead_code)]
 struct MinerIdentity {
     owner: AccountId32,
     id: u32,
@@ -38,6 +39,7 @@ struct MinerIdentity {
 pub static PATHS: OnceCell<Paths> = OnceCell::new();
 pub static STORAGE_LOCATION: OnceCell<String> = OnceCell::new();
 pub static PARACHAIN_CLIENT: OnceCell<OnlineClient<PolkadotConfig>> = OnceCell::new();
+#[allow(dead_code)]
 pub static CESS_GATEWAY: Lazy<Arc<RwLock<String>>> =
     Lazy::new(|| Arc::new(RwLock::new(String::from("https://deoss-sgp.cess.network"))));
 
@@ -46,7 +48,7 @@ pub static CESS_GATEWAY: Lazy<Arc<RwLock<String>>> =
 /// # Arguments
 /// * `parachain_url` - A string representing the URL of the parachain node to connect to.
 /// * `account_seed` - A string representing the seed phrase for generating the keypair.
-pub async fn run_config(parachain_url: &str, account: Keypair) {
+pub async fn run_config(parachain_url: &str, _account: Keypair) {
     dotenv::dotenv().ok();
 
     let storage_location = String::from(env::var("STORAGE_LOCATION").expect("STORAGE_LOCATION must be set"));
@@ -115,10 +117,12 @@ pub fn get_paths() -> Result<&'static Paths> {
     PATHS.get().ok_or(Error::config_paths_not_initialized())
 }
 
+#[allow(dead_code)]
 pub async fn get_cess_gateway() -> String {
     CESS_GATEWAY.read().await.clone()
 }
 
+#[allow(dead_code)]
 pub async fn set_cess_gateway(url: &str) {
     let mut write_guard = CESS_GATEWAY.write().await;
 

--- a/miner/src/error.rs
+++ b/miner/src/error.rs
@@ -6,6 +6,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// The custom error enum for the cyborg worker. This error enum covers all of the error variants that can occur,
 /// enabling all errors to be handled with the `?` operator, but not preventing handling the errors more precisely.
 #[derive(Debug, From)]
+#[allow(dead_code)]
 pub enum Error {
     #[from]
     Custom(String),
@@ -30,6 +31,7 @@ pub enum Error {
     Cess(cess_rust_sdk::core::Error),
 }
 
+#[allow(dead_code)]
 impl Error {
     pub fn custom(val: impl std::fmt::Display) -> Self {
         Self::Custom(val.to_string())

--- a/miner/src/log.rs
+++ b/miner/src/log.rs
@@ -21,6 +21,7 @@ pub fn init_logger() {
     *LOG_GUARD.lock().unwrap() = Some(guard);
 }
 
+#[allow(dead_code)]
 fn reset_log_file() -> Result<()> {
     *LOG_GUARD.lock().unwrap() = None;
 

--- a/miner/src/parachain_interactor/registration.rs
+++ b/miner/src/parachain_interactor/registration.rs
@@ -10,6 +10,7 @@ use std::fs;
 use subxt::utils::AccountId32;
 
 #[derive(Deserialize)]
+#[allow(dead_code)]
 struct Identity {
     miner_owner: String,
     miner_identity: (AccountId32, u64),

--- a/miner/src/parent_runtime/inference.rs
+++ b/miner/src/parent_runtime/inference.rs
@@ -32,6 +32,7 @@ pub enum InferenceEngine {
 }
 
 #[derive(Clone)]
+#[allow(dead_code)]
 struct AppState {
     task: CurrentTask,
     engine: InferenceEngine,
@@ -117,7 +118,7 @@ pub async fn spawn_inference_server(
             let _ = status_tx.send(EngineStatus::Initializing);
 
             match &engine {
-                InferenceEngine::OpenInference(client) => {
+                InferenceEngine::OpenInference(_client) => {
                     let _ = status_tx.send(EngineStatus::Ready);
 
                 }

--- a/miner/src/specs.rs
+++ b/miner/src/specs.rs
@@ -6,7 +6,7 @@ use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 
 use crate::{
     error::Result,
-    substrate_interface::api::runtime_types::bounded_collections::bounded_vec::BoundedVec,
+    /*substrate_interface::api::runtime_types::bounded_collections::bounded_vec::BoundedVec,*/
     types::{IpResponse, MinerConfig},
 };
 

--- a/miner/src/traits.rs
+++ b/miner/src/traits.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+// use std::path::PathBuf;
 
 use crate::{
     error::Result,
@@ -95,6 +95,7 @@ pub trait ParachainInteractor {
     ///
     /// # Returns
     /// A `Result` indicating `Ok(())` if the miner is successfully suspended, or an `Error` if it fails.
+#[allow(dead_code)]
     async fn suspend_miner(&self) -> Result<()>;
 }
 

--- a/miner/src/types.rs
+++ b/miner/src/types.rs
@@ -1,4 +1,4 @@
-use crate::substrate_interface::api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
+// use crate::substrate_interface::api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
 use codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -20,6 +20,7 @@ pub struct CurrentTask {
 }
 
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub enum TaskType {
     OpenInference,
     NeuroZk,
@@ -49,6 +50,7 @@ pub struct AccountKeypair(pub Keypair);
 /// Represents a client for interacting with the Cyborg parachain.
 ///
 /// This struct is used to interact with the Cyborg parachain, manage key pairs
+#[allow(dead_code)]
 pub struct Miner {
     // Some fields wrapped in an Arc to eg. keep extraction out of an RwLock before await cheap
     pub(crate) keypair: Keypair,

--- a/miner/src/utils/substrate_queries.rs
+++ b/miner/src/utils/substrate_queries.rs
@@ -3,12 +3,14 @@ use subxt::utils::AccountId32;
 use subxt::{OnlineClient, PolkadotConfig};
 
 // Struct that contains the data that the worker needs to execute a task
+#[allow(dead_code)]
 pub struct CyborgTask {
     pub id: u64,
     pub owner: AccountId32,
     pub cid: String,
 }
 
+#[allow(dead_code)]
 pub async fn get_task(api: &OnlineClient<PolkadotConfig>, task_id: u64) -> Result<CyborgTask> {
     let task_address = substrate_interface::api::storage()
         .task_management()

--- a/miner/src/utils/tx_queue.rs
+++ b/miner/src/utils/tx_queue.rs
@@ -30,6 +30,7 @@ pub struct Transaction {
     retry_count: u32,
 }
 
+#[allow(dead_code)]
 impl Transaction {
     fn new(executor: TxExecutor, responder: Option<oneshot::Sender<Result<TxOutput>>>) -> Self {
         Self {

--- a/neuro-zk-runtime/src/lib.rs
+++ b/neuro-zk-runtime/src/lib.rs
@@ -22,7 +22,7 @@ const MODEL_PATH: &str = "network.ezkl";
 const SETTINGS_PATH: &str = "settings.json";
 const PROVING_KEY_PATH: &str = "pk.key";
 const PROOF_INPUT_PATH: &str = "input.json";
-const PROOF_WITNESS_PATH: &str = "proof-witness.json";
+// const PROOF_WITNESS_PATH: &str = "proof-witness.json";
 const WITNESS_PATH: &str = "witness.json";
 const SRS_PATH: &str = "kzg.srs";
 
@@ -314,8 +314,8 @@ impl NeuroZKEngine {
         input_data: String,
     ) -> Result<String, Box<dyn std::error::Error>> {
         let model_path = PathBuf::from(format!("{}/{}", prefix, model_path));
-        let srs_path = PathBuf::from(format!("{}/{}", prefix, srs_path));
-        let witness_path = PathBuf::from(format!("{}/{}", prefix, witness_path));
+        let _srs_path = PathBuf::from(format!("{}/{}", prefix, srs_path));
+        let _witness_path = PathBuf::from(format!("{}/{}", prefix, witness_path));
 
         println!("Generating inference result for: {}", input_data);
 


### PR DESCRIPTION
- Miner now immediately confirms task reception when receiving a TaskScheduled event

- Uses transaction queue for reliable confirmation submission

- Handles confirmation responses and errors

- Works with parachain's new timeout enforcement

