### PR TITLE
feat: Implement dual logging system for miner owners and end-users

### DIFF
--- a/miner/src/config.rs
+++ b/miner/src/config.rs
@@ -56,8 +56,8 @@ pub async fn run_config(parachain_url: &str, _account: Keypair) {
 
     let storage_location = String::from(env::var("STORAGE_LOCATION").expect("STORAGE_LOCATION must be set"));
     let log_path = PathBuf::from(env::var("LOG_FILE_PATH").expect("LOG_PATH must be set"));
-    let operator_log_path = PathBuf::from(env::var("OPERATOR_LOG_PATH").unwrap_or("miner/logs/operator/miner_operator.log".to_string()));  // NEW
-    let user_log_path = PathBuf::from(env::var("USER_LOG_PATH").unwrap_or("miner/logs/user/miner_user.log".to_string()));  // NEW
+    let operator_log_path = PathBuf::from(env::var("OPERATOR_LOG_PATH").unwrap_or("miner/logs/operator/miner_operator.log".to_string()));
+    let user_log_path = PathBuf::from(env::var("USER_LOG_PATH").unwrap_or("miner/logs/user/miner_user.log".to_string()));
     let task_file_name = String::from(env::var("TASK_FILE_NAME").expect("TASK_FILE_NAME must be set"));
     let task_dir_path = String::from(env::var("TASK_DIR_PATH").expect("TASK_DIR_PATH must be set"));
     let identity_path = String::from(env::var("IDENTITY_FILE_PATH").expect("IDENTITY_PATH must be set"));

--- a/miner/src/config.rs
+++ b/miner/src/config.rs
@@ -22,11 +22,14 @@ use crate::utils::tx_queue::TRANSACTION_QUEUE;
 #[derive(Debug)]
 pub struct Paths {
     pub log_path: PathBuf,
+    pub operator_log_path: PathBuf,
+    pub user_log_path: PathBuf,
     pub task_file_name: String,
     pub task_dir_path: String,
     pub task_owner_path: String,
     pub identity_path: String,
 }
+
 
 #[derive(Deserialize, Debug)]
 #[allow(dead_code)]
@@ -53,13 +56,12 @@ pub async fn run_config(parachain_url: &str, _account: Keypair) {
 
     let storage_location = String::from(env::var("STORAGE_LOCATION").expect("STORAGE_LOCATION must be set"));
     let log_path = PathBuf::from(env::var("LOG_FILE_PATH").expect("LOG_PATH must be set"));
-    let task_file_name =
-        String::from(env::var("TASK_FILE_NAME").expect("TASK_FILE_NAME must be set"));
+    let operator_log_path = PathBuf::from(env::var("OPERATOR_LOG_PATH").unwrap_or("miner/logs/operator/miner_operator.log".to_string()));  // NEW
+    let user_log_path = PathBuf::from(env::var("USER_LOG_PATH").unwrap_or("miner/logs/user/miner_user.log".to_string()));  // NEW
+    let task_file_name = String::from(env::var("TASK_FILE_NAME").expect("TASK_FILE_NAME must be set"));
     let task_dir_path = String::from(env::var("TASK_DIR_PATH").expect("TASK_DIR_PATH must be set"));
-    let identity_path =
-        String::from(env::var("IDENTITY_FILE_PATH").expect("IDENTITY_PATH must be set"));
-    let task_owner_path =
-        String::from(env::var("TASK_OWNER_FILE_PATH").expect("TASK_OWNER_PATH must be set"));
+    let identity_path = String::from(env::var("IDENTITY_FILE_PATH").expect("IDENTITY_PATH must be set"));
+    let task_owner_path = String::from(env::var("TASK_OWNER_FILE_PATH").expect("TASK_OWNER_PATH must be set"));
     let parachain_url = if let Ok(parachain_url_env) = env::var("PARACHAIN_URL") {
         parachain_url_env
     } else {
@@ -71,6 +73,8 @@ pub async fn run_config(parachain_url: &str, _account: Keypair) {
     PATHS
         .set(Paths {
             log_path,
+            operator_log_path, 
+            user_log_path,
             task_file_name,
             task_dir_path,
             task_owner_path,

--- a/miner/src/error.rs
+++ b/miner/src/error.rs
@@ -3,6 +3,9 @@ use derive_more::From;
 /// A type alias for a `Result` with the custom error enum `Error`.
 pub type Result<T> = core::result::Result<T, Error>;
 
+use tracing::subscriber::SetGlobalDefaultError;
+
+
 /// The custom error enum for the cyborg worker. This error enum covers all of the error variants that can occur,
 /// enabling all errors to be handled with the `?` operator, but not preventing handling the errors more precisely.
 #[derive(Debug, From)]
@@ -29,6 +32,9 @@ pub enum Error {
 
     #[from]
     Cess(cess_rust_sdk::core::Error),
+
+    #[from]
+    Tracing(SetGlobalDefaultError),
 }
 
 #[allow(dead_code)]

--- a/miner/src/log.rs
+++ b/miner/src/log.rs
@@ -1,31 +1,84 @@
 use crate::error::Result;
 use once_cell::sync::Lazy;
+use std::path::PathBuf;
 use std::sync::Mutex;
 use tracing_appender::non_blocking;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::fmt::writer::BoxMakeWriter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::Layer;
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 
-static LOG_GUARD: Lazy<Mutex<Option<WorkerGuard>>> = Lazy::new(|| Mutex::new(None));
+static LOG_GUARD: Lazy<Mutex<Option<(WorkerGuard, WorkerGuard)>>> = Lazy::new(|| Mutex::new(None));
 
-pub fn init_logger() {
-    let file_appender = tracing_appender::rolling::never("miner/logs", "miner.log");
+pub fn init_logger() -> Result<()> {
+    // Create directories if they don't exist
+    std::fs::create_dir_all("miner/logs")?;
+    std::fs::create_dir_all("miner/logs/operator")?;
+    std::fs::create_dir_all("miner/logs/user")?;
 
-    let (non_blocking_writer, guard) = non_blocking(file_appender);
+    // Operator logs (miner owner) - more verbose
+    let operator_appender =
+        tracing_appender::rolling::never("miner/logs/operator", "miner_operator.log");
+    let (non_blocking_operator, operator_guard) = non_blocking(operator_appender);
 
-    tracing_subscriber::fmt()
-        .with_writer(BoxMakeWriter::new(non_blocking_writer))
+    // User logs (end user) - less verbose
+    let user_appender = tracing_appender::rolling::never("miner/logs/user", "miner_user.log");
+    let (non_blocking_user, user_guard) = non_blocking(user_appender);
+
+    // Create filter for operator logs (DEBUG level)
+    let operator_filter = EnvFilter::from_default_env()
+        .add_directive(LevelFilter::DEBUG.into());
+
+    // Create filter for user logs (INFO level)
+    let user_filter = EnvFilter::from_default_env()
+        .add_directive(LevelFilter::INFO.into());
+
+    // Operator layer - more detailed logs
+    let operator_layer = tracing_subscriber::fmt::layer()
+        .with_writer(BoxMakeWriter::new(non_blocking_operator))
         .with_ansi(false)
         .with_level(true)
-        .init();
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_filter(operator_filter);
 
-    *LOG_GUARD.lock().unwrap() = Some(guard);
+    // User layer - less detailed logs
+    let user_layer = tracing_subscriber::fmt::layer()
+        .with_writer(BoxMakeWriter::new(non_blocking_user))
+        .with_ansi(false)
+        .with_level(true)
+        .with_target(false)
+        .with_thread_ids(false)
+        .with_filter(user_filter);
+
+    // Combined subscriber with both layers
+    let subscriber = tracing_subscriber::registry()
+        .with(operator_layer)
+        .with(user_layer);
+
+    subscriber.init();
+
+    *LOG_GUARD.lock().unwrap() = Some((operator_guard, user_guard));
+    Ok(())
 }
 
 #[allow(dead_code)]
-fn reset_log_file() -> Result<()> {
+fn reset_log_files() -> Result<()> {
     *LOG_GUARD.lock().unwrap() = None;
 
-    std::fs::remove_file("miner/logs/miner.log")?;
+    let _ = std::fs::remove_file("miner/logs/operator/miner_operator.log");
+    let _ = std::fs::remove_file("miner/logs/user/miner_user.log");
 
     Ok(())
+}
+
+// Helper function to get log file paths
+pub fn get_operator_log_path() -> PathBuf {
+    PathBuf::from("miner/logs/operator/miner_operator.log")
+}
+
+pub fn get_user_log_path() -> PathBuf {
+    PathBuf::from("miner/logs/user/miner_user.log")
 }

--- a/miner/src/main.rs
+++ b/miner/src/main.rs
@@ -30,14 +30,17 @@ use clap::Parser;
 use cli::{Cli, Commands};
 use config::run_config;
 use error::Result;
+use std::str::FromStr;
+use subxt_signer::sr25519::Keypair;
 use subxt_signer::SecretUri;
 use traits::ParachainInteractor;
-use subxt_signer::sr25519::Keypair;
-use std::str::FromStr;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Initialize logger first
+    log::init_logger().expect("Failed to initialize logger");
 
     // Match on the provided subcommand and execute the corresponding action.
     match &cli.command {
@@ -46,8 +49,6 @@ async fn main() -> Result<()> {
             parachain_url,
             account_seed,
         }) => {
-            let _log_guard = log::init_logger();
-
             let uri = SecretUri::from_str(account_seed).expect("Keypair was not set correctly");
             let keypair = Keypair::from_uri(&uri).expect("Keypair from URI failed");
 

--- a/miner/src/utils/log_utils.rs
+++ b/miner/src/utils/log_utils.rs
@@ -1,0 +1,34 @@
+use crate::error::Result;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::PathBuf;
+
+pub fn read_log_file(path: &PathBuf, lines: Option<usize>) -> Result<String> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    
+    let mut content = String::new();
+    reader.read_to_string(&mut content)?;
+    
+    if let Some(line_count) = lines {
+        let lines: Vec<&str> = content.lines().collect();
+        let start = if lines.len() > line_count {
+            lines.len() - line_count
+        } else {
+            0
+        };
+        content = lines[start..].join("\n");
+    }
+    
+    Ok(content)
+}
+
+pub fn get_operator_logs(lines: Option<usize>) -> Result<String> {
+    let path = crate::config::get_paths()?.operator_log_path.clone();
+    read_log_file(&path, lines)
+}
+
+pub fn get_user_logs(lines: Option<usize>) -> Result<String> {
+    let path = crate::config::get_paths()?.user_log_path.clone();
+    read_log_file(&path, lines)
+}

--- a/miner/src/utils/mod.rs
+++ b/miner/src/utils/mod.rs
@@ -2,3 +2,4 @@ pub mod substrate_queries;
 //pub mod substrate_transactions;
 pub mod tx_queue;
 pub mod tx_builder;
+pub mod log_utils;


### PR DESCRIPTION
The current logging implementation only provides a single log file `(miner.log)` that is accessible to both miner owners and end-users. This lacks proper separation and doesn't allow miner operators to view detailed operational logs while restricting end-users to only relevant task-specific logs.

This PR Implements a dual logging system that creates separate log files for:

- Operator logs `(miner/logs/operator/miner_operator.log)`: Detailed DEBUG-level logs with thread IDs, targets, and comprehensive operational data for miner owners

- User logs `(miner/logs/user/miner_user.log)`: INFO-level logs with simplified output for end-users